### PR TITLE
Fix installation documentation to reflect current build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,22 @@ weblook --mcp-client http://localhost:8000 https://example.com
 
 ## Installation
 
-```bash
-# Install without experimental MCP support
-cargo install weblook
+WebLook is currently not available on crates.io. To install:
 
-# Install with experimental MCP support
-cargo install weblook --features mcp_experimental
+```bash
+# Clone the repository
+git clone https://github.com/username/weblook.git
+cd weblook
+
+# Build and install without experimental MCP support
+cargo build --release
+
+# Build with experimental MCP support
+cargo build --release --features mcp_experimental
+
+# The binary will be available at target/release/weblook
+# You can copy it to a directory in your PATH for easier access
+cp target/release/weblook ~/.local/bin/  # or another directory in your PATH
 ```
 
 ## Requirements


### PR DESCRIPTION
# Update Installation Documentation

## Summary
This PR updates the README.md to correct the installation instructions, fixing issue #1 . The previous documentation incorrectly suggested that WebLook could be installed via `cargo install`, but the tool is not currently published on crates.io and must be built from source.

## Changes
- Removed incorrect `cargo install` instructions
- Added complete workflow for installing from source:
  - Cloning the repository
  - Building with cargo (with and without experimental features)
  - Instructions for making the binary accessible in PATH
- Maintained consistency with the rest of the documentation

## Why This Matters
Accurate installation instructions are critical for new users trying to use the tool. This change ensures users can successfully install WebLook without confusion or errors from attempting to use unavailable installation methods.

## Testing
Verified that the instructions are clear, complete, and follow the actual required installation process.